### PR TITLE
Fix include paths for dependent projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,7 @@
 cmake_minimum_required(VERSION 2.8.12)
-project(cppunit)
-set(CPPUNIT_PACKAGE_NAME cppunit CACHE STRING "Name of the package to build.")
-set(CPPUNIT_MAJOR_VERSION 1 CACHE STRING "Major (first) version number.")
-set(CPPUNIT_MINOR_VERSION 14 CACHE STRING "Minor (second) version number.")
-set(CPPUNIT_PATCH_VERSION 2 CACHE STRING "Patch (third) version number.")
-set(CPPUNIT_VERSION "${CPPUNIT_MAJOR_VERSION}.${CPPUNIT_MINOR_VERSION}.${CPPUNIT_PATCH_VERSION}")
+cmake_policy(SET CMP0048 NEW)
+
+project(cppunit VERSION 1.14.2 LANGUAGES CXX)
 
 if(NOT ${CMAKE_VERSION} VERSION_LESS 3.1)
     set(CMAKE_CXX_STANDARD 11)
@@ -100,7 +97,7 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cppunit/config-auto.h DESTINATION ${CM
 
 include(CMakePackageConfigHelpers)
 configure_package_config_file(cppunitConfig.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/cppunitConfig.cmake INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cppunit)
-write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/cppunitConfigVersion.cmake VERSION ${CPPUNIT_VERSION} COMPATIBILITY SameMajorVersion)
+write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/cppunitConfigVersion.cmake COMPATIBILITY SameMajorVersion)
 
 install(FILES
     ${CMAKE_CURRENT_BINARY_DIR}/cppunitConfig.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,16 +63,19 @@ set(Sources
     src/cppunit/XmlOutputter.cpp
     src/cppunit/XmlOutputterHook.cpp
 )
-set(HeaderDirs
-    src/cppunit
-    include
-)
 
 configure_file("config-auto.h.in" "cppunit/config-auto.h")
 
 #Build cppunit's library.
-include_directories(${HeaderDirs} ${CMAKE_BINARY_DIR})
 add_library(cppunit STATIC ${Sources})
+add_library(cppunit::cppunit ALIAS cppunit)
+target_include_directories(cppunit
+    PRIVATE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/cppunit>
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+        $<INSTALL_INTERFACE:include>)
 
 #Installation.
 include(GNUInstallDirs)
@@ -82,24 +85,25 @@ install(TARGETS cppunit
 )
 
 install(EXPORT cppunit-targets
+    NAMESPACE cppunit::
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cppunit
 )
 
 install(
     DIRECTORY include
-    DESTINATION ${CMAKE_INSTALL_PREFIX}
+    DESTINATION .
     FILES_MATCHING PATTERN *.h
     REGEX "msvc6" EXCLUDE
 )
 
-install(FILES ${CMAKE_BINARY_DIR}/cppunit/config-auto.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cppunit)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cppunit/config-auto.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cppunit)
 
 include(CMakePackageConfigHelpers)
-configure_package_config_file(cppunitConfig.cmake.in ${CMAKE_BINARY_DIR}/cppunitConfig.cmake INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cppunit)
-write_basic_package_version_file(${CMAKE_BINARY_DIR}/cppunitConfigVersion.cmake VERSION ${CPPUNIT_VERSION} COMPATIBILITY SameMajorVersion)
+configure_package_config_file(cppunitConfig.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/cppunitConfig.cmake INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cppunit)
+write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/cppunitConfigVersion.cmake VERSION ${CPPUNIT_VERSION} COMPATIBILITY SameMajorVersion)
 
 install(FILES
-    ${CMAKE_BINARY_DIR}/cppunitConfig.cmake
-    ${CMAKE_BINARY_DIR}/cppunitConfigVersion.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/cppunitConfig.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/cppunitConfigVersion.cmake
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cppunit
 )

--- a/config-auto.h.in
+++ b/config-auto.h.in
@@ -127,7 +127,7 @@
 
 /* Name of package */
 #ifndef CPPUNIT_PACKAGE 
-#define CPPUNIT_PACKAGE  "${CPPUNIT_PACKAGE_NAME}"
+#define CPPUNIT_PACKAGE  "${PROJECT_NAME}"
 #endif
 
 /* Define to the address where bug reports for this package should be sent. */
@@ -136,18 +136,18 @@
 #endif
 
 /* Define to the full name of this package. */
-#ifndef CPPUNIT_PACKAGE_NAME 
-#define CPPUNIT_PACKAGE_NAME  "${CPPUNIT_PACKAGE_NAME}"
+#ifndef CPPUNIT_PACKAGE_NAME
+#define CPPUNIT_PACKAGE_NAME  "${PROJECT_NAME}"
 #endif
 
 /* Define to the full name and version of this package. */
 #ifndef CPPUNIT_PACKAGE_STRING 
-#define CPPUNIT_PACKAGE_STRING  "${CPPUNIT_PACKAGE_NAME} ${CPPUNIT_MAJOR_VERSION}.${CPPUNIT_MINOR_VERSION}.${CPPUNIT_PATCH_VERSION}"
+#define CPPUNIT_PACKAGE_STRING  "${PROJECT_NAME} ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}"
 #endif
 
 /* Define to the one symbol short name of this package. */
 #ifndef CPPUNIT_PACKAGE_TARNAME 
-#define CPPUNIT_PACKAGE_TARNAME  "${CPPUNIT_PACKAGE_NAME}"
+#define CPPUNIT_PACKAGE_TARNAME  "${PROJECT_NAME}"
 #endif
 
 /* Define to the home page for this package. */
@@ -157,7 +157,7 @@
 
 /* Define to the version of this package. */
 #ifndef CPPUNIT_PACKAGE_VERSION 
-#define CPPUNIT_PACKAGE_VERSION  "${CPPUNIT_MAJOR_VERSION}.${CPPUNIT_MINOR_VERSION}.${CPPUNIT_PATCH_VERSION}"
+#define CPPUNIT_PACKAGE_VERSION  "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}"
 #endif
 
 /* Define to 1 if you have the ANSI C header files. */
@@ -171,8 +171,8 @@
 #endif
 
 /* Version number of package */
-#ifndef CPPUNIT_VERSION 
-#define CPPUNIT_VERSION  "${CPPUNIT_MAJOR_VERSION}.${CPPUNIT_MINOR_VERSION}.${CPPUNIT_PATCH_VERSION}"
+#ifndef CPPUNIT_VERSION
+#define CPPUNIT_VERSION  "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}"
 #endif
  
 /* _INCLUDE_CPPUNIT_CONFIG_AUTO_H */

--- a/configure.ac
+++ b/configure.ac
@@ -7,7 +7,7 @@ AC_PREREQ([2.65])
 # ====================
 m4_define([cppunit_version_major],[1])
 m4_define([cppunit_version_minor],[14])
-m4_define([cppunit_version_micro],[0])
+m4_define([cppunit_version_micro],[2])
 m4_define([cppunit_version],[cppunit_version_major.cppunit_version_minor.cppunit_version_micro])
 m4_define([cppunit_interface_age], [0])
 m4_define([cppunit_binary_age], [0])

--- a/include/cppunit/Portability.h
+++ b/include/cppunit/Portability.h
@@ -19,8 +19,8 @@
 #endif
 
 // Version number of package
-#ifndef CPPUNIT_VERSION 
-#define CPPUNIT_VERSION  "1.14.0"
+#ifndef CPPUNIT_VERSION
+#define CPPUNIT_VERSION  "1.14.2"
 #endif
  
 #include <cppunit/config/CppUnitApi.h>    // define CPPUNIT_API & CPPUNIT_NEED_DLL_DECL


### PR DESCRIPTION
Use paths for current project as CMAKE_BINARY_DIR can point to a project
that includes this one, e.g. by add_subdirectory().
Remove source directory from INTERFACE_INCLUDE_DIRECTORIES by using
absolute paths and separate build and install interfaces.
Fix include installation directory when CMAKE_INSTALL_PREFIX is set.
Add namespaced target alias.